### PR TITLE
Anonymous Posts Feature(merge branch into main)

### DIFF
--- a/public/language/en-GB/anonymous.json
+++ b/public/language/en-GB/anonymous.json
@@ -1,0 +1,3 @@
+{
+    "post-anonymously": "Post anonymously"
+}

--- a/public/openapi/components/schemas/PostObject.yaml
+++ b/public/openapi/components/schemas/PostObject.yaml
@@ -54,7 +54,8 @@ PostObject:
           description: This is either username or fullname depending on forum and user settings
         userslug:
           type: string
-          description: An URL-safe variant of the username (i.e. lower-cased, spaces
+          description:
+            An URL-safe variant of the username (i.e. lower-cased, spaces
             removed, etc.)
         picture:
           type: string
@@ -63,12 +64,14 @@ PostObject:
           type: string
         icon:text:
           type: string
-          description: A single-letter representation of a username. This is used in the
+          description:
+            A single-letter representation of a username. This is used in the
             auto-generated icon given to users without
             an avatar
         icon:bgColor:
           type: string
-          description: A six-character hexadecimal colour code assigned to the user. This
+          description:
+            A six-character hexadecimal colour code assigned to the user. This
             value is used in conjunction with
             `icon:text` for the user's auto-generated
             icon
@@ -102,7 +105,8 @@ PostObject:
           type: number
         mainPid:
           type: number
-          description: The post id of the first post in this topic (also called the
+          description:
+            The post id of the first post in this topic (also called the
             "original post")
         teaserPid:
           type: number
@@ -140,7 +144,8 @@ PostObject:
           type: string
         parentCid:
           type: number
-          description: The category identifier for the category that is the immediate
+          description:
+            The category identifier for the category that is the immediate
             ancestor of the current category
         bgColor:
           type: string
@@ -155,6 +160,9 @@ PostObject:
       type: boolean
     replies:
       type: number
+    anonymous:
+      type: number
+      description: Whether this post was made anonymously (0 for false, 1 for true)
 PostDataObject:
   description: The output as returned from `Posts.getPostsData`
   allOf:
@@ -212,7 +220,8 @@ PostDataObject:
               description: This is either username or fullname depending on forum and user settings
             userslug:
               type: string
-              description: An URL-safe variant of the username (i.e. lower-cased, spaces
+              description:
+                An URL-safe variant of the username (i.e. lower-cased, spaces
                 removed, etc.)
             reputation:
               type: number
@@ -249,12 +258,14 @@ PostDataObject:
               nullable: true
             icon:text:
               type: string
-              description: A single-letter representation of a username. This is used in the
+              description:
+                A single-letter representation of a username. This is used in the
                 auto-generated icon given to users without
                 an avatar
             icon:bgColor:
               type: string
-              description: A six-character hexadecimal colour code assigned to the user. This
+              description:
+                A six-character hexadecimal colour code assigned to the user. This
                 value is used in conjunction with
                 `icon:text` for the user's auto-generated
                 icon
@@ -298,6 +309,9 @@ PostDataObject:
           type: boolean
         downvoted:
           type: boolean
+        anonymous:
+          type: number
+          description: Whether this post was made anonymously (0 for false, 1 for true)
         attachments:
           type: array
         replies:
@@ -315,7 +329,8 @@ PostDataObject:
                     description: A friendly name for a given user account
                   userslug:
                     type: string
-                    description: An URL-safe variant of the username (i.e. lower-cased, spaces
+                    description:
+                      An URL-safe variant of the username (i.e. lower-cased, spaces
                       removed, etc.)
                   picture:
                     type: string
@@ -324,12 +339,14 @@ PostDataObject:
                     description: A user identifier
                   icon:text:
                     type: string
-                    description: A single-letter representation of a username. This is used in the
+                    description:
+                      A single-letter representation of a username. This is used in the
                       auto-generated icon given to users without
                       an avatar
                   icon:bgColor:
                     type: string
-                    description: A six-character hexadecimal colour code assigned to the user. This
+                    description:
+                      A six-character hexadecimal colour code assigned to the user. This
                       value is used in conjunction with
                       `icon:text` for the user's auto-generated
                       icon

--- a/public/openapi/read/categories.yaml
+++ b/public/openapi/read/categories.yaml
@@ -96,19 +96,22 @@ get:
                                                   description: A friendly name for a given user account
                                                 userslug:
                                                   type: string
-                                                  description: An URL-safe variant of the username (i.e. lower-cased, spaces
+                                                  description:
+                                                    An URL-safe variant of the username (i.e. lower-cased, spaces
                                                     removed, etc.)
                                                 picture:
                                                   nullable: true
                                                   type: string
                                                 icon:text:
                                                   type: string
-                                                  description: A single-letter representation of a username. This is used in the
+                                                  description:
+                                                    A single-letter representation of a username. This is used in the
                                                     auto-generated icon given to
                                                     users without an avatar
                                                 icon:bgColor:
                                                   type: string
-                                                  description: A six-character hexadecimal colour code assigned to the user. This
+                                                  description:
+                                                    A six-character hexadecimal colour code assigned to the user. This
                                                     value is used in conjunction
                                                     with `icon:text` for the user's
                                                     auto-generated icon
@@ -125,6 +128,9 @@ get:
                                                   type: string
                                                 title:
                                                   type: string
+                                            anonymous:
+                                              type: number
+                                              description: Whether this post was made anonymously (0 for false, 1 for true)
                                       imageClass:
                                         type: string
                                       timesClicked:
@@ -165,19 +171,22 @@ get:
                                         description: This is either username or fullname depending on forum and user settings
                                       userslug:
                                         type: string
-                                        description: An URL-safe variant of the username (i.e. lower-cased, spaces
+                                        description:
+                                          An URL-safe variant of the username (i.e. lower-cased, spaces
                                           removed, etc.)
                                       picture:
                                         nullable: true
                                         type: string
                                       icon:text:
                                         type: string
-                                        description: A single-letter representation of a username. This is used in the
+                                        description:
+                                          A single-letter representation of a username. This is used in the
                                           auto-generated icon given to users
                                           without an avatar
                                       icon:bgColor:
                                         type: string
-                                        description: A six-character hexadecimal colour code assigned to the user. This
+                                        description:
+                                          A six-character hexadecimal colour code assigned to the user. This
                                           value is used in conjunction with
                                           `icon:text` for the user's
                                           auto-generated icon
@@ -196,6 +205,9 @@ get:
                                         type: string
                                       title:
                                         type: string
+                                  anonymous:
+                                    type: number
+                                    description: Whether this post was made anonymously (0 for false, 1 for true)
                             teaser:
                               type: object
                               properties:
@@ -223,32 +235,32 @@ get:
                                 user:
                                   type: object
                                   properties:
-                                      uid:
-                                        type: number
-                                        example: 1
-                                      isLocal:
-                                        type: boolean
-                                        description: Whether the user belongs to the local installation or not.
-                                      username:
-                                        type: string
-                                        example: Dragon Fruit
-                                      userslug:
-                                        type: string
-                                        example: dragon-fruit
-                                      picture:
-                                        type: string
-                                        example: 'https://images.unsplash.com/photo-1560070094-e1f2ddec4337?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=256&h=256&q=80'
-                                        nullable: true
-                                      displayname:
-                                        type: string
-                                        description: This is either username or fullname depending on forum and user settings
-                                        example: Dragon Fruit
-                                      'icon:text':
-                                        type: string
-                                        example: D
-                                      'icon:bgColor':
-                                        type: string
-                                        example: '#9c27b0'
+                                    uid:
+                                      type: number
+                                      example: 1
+                                    isLocal:
+                                      type: boolean
+                                      description: Whether the user belongs to the local installation or not.
+                                    username:
+                                      type: string
+                                      example: Dragon Fruit
+                                    userslug:
+                                      type: string
+                                      example: dragon-fruit
+                                    picture:
+                                      type: string
+                                      example: "https://images.unsplash.com/photo-1560070094-e1f2ddec4337?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=256&h=256&q=80"
+                                      nullable: true
+                                    displayname:
+                                      type: string
+                                      description: This is either username or fullname depending on forum and user settings
+                                      example: Dragon Fruit
+                                    "icon:text":
+                                      type: string
+                                      example: D
+                                    "icon:bgColor":
+                                      type: string
+                                      example: "#9c27b0"
                             imageClass:
                               type: string
               - $ref: ../components/schemas/Pagination.yaml#/Pagination

--- a/public/openapi/read/index.yaml
+++ b/public/openapi/read/index.yaml
@@ -94,19 +94,22 @@ get:
                                                   description: This is either username or fullname depending on forum and user settings
                                                 userslug:
                                                   type: string
-                                                  description: An URL-safe variant of the username (i.e. lower-cased, spaces
+                                                  description:
+                                                    An URL-safe variant of the username (i.e. lower-cased, spaces
                                                     removed, etc.)
                                                 picture:
                                                   nullable: true
                                                   type: string
                                                 icon:text:
                                                   type: string
-                                                  description: A single-letter representation of a username. This is used in the
+                                                  description:
+                                                    A single-letter representation of a username. This is used in the
                                                     auto-generated icon given to
                                                     users without an avatar
                                                 icon:bgColor:
                                                   type: string
-                                                  description: A six-character hexadecimal colour code assigned to the user. This
+                                                  description:
+                                                    A six-character hexadecimal colour code assigned to the user. This
                                                     value is used in conjunction
                                                     with `icon:text` for the user's
                                                     auto-generated icon
@@ -118,7 +121,8 @@ get:
                                               description: A category identifier
                                             parentCid:
                                               type: number
-                                              description: The category identifier for the category that is the immediate
+                                              description:
+                                                The category identifier for the category that is the immediate
                                                 ancestor of the current category
                                             topic:
                                               type: object
@@ -127,6 +131,9 @@ get:
                                                   type: string
                                                 title:
                                                   type: string
+                                            anonymous:
+                                              type: number
+                                              description: Whether this post was made anonymously (0 for false, 1 for true)
                                       imageClass:
                                         type: string
                                       timesClicked:
@@ -164,19 +171,22 @@ get:
                                         description: This is either username or fullname depending on forum and user settings
                                       userslug:
                                         type: string
-                                        description: An URL-safe variant of the username (i.e. lower-cased, spaces
+                                        description:
+                                          An URL-safe variant of the username (i.e. lower-cased, spaces
                                           removed, etc.)
                                       picture:
                                         nullable: true
                                         type: string
                                       icon:text:
                                         type: string
-                                        description: A single-letter representation of a username. This is used in the
+                                        description:
+                                          A single-letter representation of a username. This is used in the
                                           auto-generated icon given to users
                                           without an avatar
                                       icon:bgColor:
                                         type: string
-                                        description: A six-character hexadecimal colour code assigned to the user. This
+                                        description:
+                                          A six-character hexadecimal colour code assigned to the user. This
                                           value is used in conjunction with
                                           `icon:text` for the user's
                                           auto-generated icon
@@ -198,6 +208,9 @@ get:
                                         type: string
                                       title:
                                         type: string
+                                  anonymous:
+                                    type: number
+                                    description: Whether this post was made anonymously (0 for false, 1 for true)
                             teaser:
                               type: object
                               properties:
@@ -225,32 +238,32 @@ get:
                                 user:
                                   type: object
                                   properties:
-                                      uid:
-                                        type: number
-                                        example: 1
-                                      username:
-                                        type: string
-                                        example: Dragon Fruit
-                                      userslug:
-                                        type: string
-                                        example: dragon-fruit
-                                      picture:
-                                        type: string
-                                        example: 'https://images.unsplash.com/photo-1560070094-e1f2ddec4337?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=256&h=256&q=80'
-                                        nullable: true
-                                      displayname:
-                                        type: string
-                                        description: This is either username or fullname depending on forum and user settings
-                                        example: Dragon Fruit
-                                      'icon:text':
-                                        type: string
-                                        example: D
-                                      'icon:bgColor':
-                                        type: string
-                                        example: '#9c27b0'
-                                      isLocal:
-                                        type: boolean
-                                        description: Whether the user belongs to the local installation or not.
+                                    uid:
+                                      type: number
+                                      example: 1
+                                    username:
+                                      type: string
+                                      example: Dragon Fruit
+                                    userslug:
+                                      type: string
+                                      example: dragon-fruit
+                                    picture:
+                                      type: string
+                                      example: "https://images.unsplash.com/photo-1560070094-e1f2ddec4337?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=256&h=256&q=80"
+                                      nullable: true
+                                    displayname:
+                                      type: string
+                                      description: This is either username or fullname depending on forum and user settings
+                                      example: Dragon Fruit
+                                    "icon:text":
+                                      type: string
+                                      example: D
+                                    "icon:bgColor":
+                                      type: string
+                                      example: "#9c27b0"
+                                    isLocal:
+                                      type: boolean
+                                      description: Whether the user belongs to the local installation or not.
                             imageClass:
                               type: string
               - $ref: ../components/schemas/Pagination.yaml#/Pagination

--- a/public/src/app.js
+++ b/public/src/app.js
@@ -109,12 +109,14 @@ if (document.readyState === 'loading') {
 			'search',
 			'forum/header',
 			'hooks',
-		], function (taskbar, helpers, pagination, messages, search, header, hooks) {
+			'anonymous',
+		], function (taskbar, helpers, pagination, messages, search, header, hooks, anonymous) {
 			header.prepareDOM();
 			taskbar.init();
 			helpers.register();
 			pagination.init();
 			search.init();
+			anonymous.init();
 			overrides.overrideTimeago();
 			hooks.fire('action:app.load');
 			messages.show();

--- a/public/src/modules/anonymous.js
+++ b/public/src/modules/anonymous.js
@@ -2,81 +2,81 @@
 
 
 define('anonymous', ['hooks'], function (hooks) {
-    const Anonymous = {};
+	const Anonymous = {};
 
 
-    Anonymous.init = function () {
-        // Handle composer enhancement - add anonymous checkbox
-        hooks.on('action:composer.enhance', function (data) {
-            Anonymous.addCheckboxToComposer(data.container);
-        });
+	Anonymous.init = function () {
+		// Handle composer enhancement - add anonymous checkbox
+		hooks.on('action:composer.enhance', function (data) {
+			Anonymous.addCheckboxToComposer(data.container);
+		});
 
 
-        // Listen to composer creation hooks
-        hooks.on('action:composer.topic.new', function () {
-            setTimeout(() => {
-                const composer = $('.composer');
-                if (composer.length) {
-                    Anonymous.addCheckboxToComposer(composer);
-                }
-            }, 100);
-        });
+		// Listen to composer creation hooks
+		hooks.on('action:composer.topic.new', function () {
+			setTimeout(() => {
+				const composer = $('.composer');
+				if (composer.length) {
+					Anonymous.addCheckboxToComposer(composer);
+				}
+			}, 100);
+		});
 
 
-        hooks.on('action:composer.post.new', function () {
-            setTimeout(() => {
-                const composer = $('.composer');
-                if (composer.length) {
-                    Anonymous.addCheckboxToComposer(composer);
-                }
-            }, 100);
-        });
+		hooks.on('action:composer.post.new', function () {
+			setTimeout(() => {
+				const composer = $('.composer');
+				if (composer.length) {
+					Anonymous.addCheckboxToComposer(composer);
+				}
+			}, 100);
+		});
 
 
-        // Handle composer submission - add anonymous data
-        hooks.on('filter:composer.submit', function (data) {
-            const composerEl = data.composerEl || $('.composer');
-            const checked = composerEl.find('#composer-anonymous').is(':checked');
+		// Handle composer submission - add anonymous data
+		hooks.on('filter:composer.submit', function (data) {
+			const composerEl = data.composerEl || $('.composer');
+			const checked = composerEl.find('#composer-anonymous').is(':checked');
 
 
-            data.composerData = data.composerData || {};
-            if (checked) {
-                data.composerData.anonymous = 1;
-            } else {
-                delete data.composerData.anonymous;
-            }
+			data.composerData = data.composerData || {};
+			if (checked) {
+				data.composerData.anonymous = 1;
+			} else {
+				delete data.composerData.anonymous;
+			}
 
 
-            return data;
-        });
-    };
+			return data;
+		});
+	};
 
 
-    Anonymous.addCheckboxToComposer = function (container) {
-        if (!container || !container.length) {
-            return;
-        }
+	Anonymous.addCheckboxToComposer = function (container) {
+		if (!container || !container.length) {
+			return;
+		}
 
 
-        // Check if checkbox already exists
-        if (container.find('#composer-anonymous').length > 0) {
-            return;
-        }
+		// Check if checkbox already exists
+		if (container.find('#composer-anonymous').length > 0) {
+			return;
+		}
 
 
-        // Look for the title container first, then fallback to other selectors
-        const selectors = [
-            '.title-container',
-            '.action-bar',
-            '.composer-submit',
-            'form',
-        ];
+		// Look for the title container first, then fallback to other selectors
+		const selectors = [
+			'.title-container',
+			'.action-bar',
+			'.composer-submit',
+			'form',
+		];
 
 
-        for (const currentSelector of selectors) {
-            const target = container.find(currentSelector).first();
-            if (target.length) {
-                const anonymousCheckbox = $(`
+		for (const currentSelector of selectors) {
+			const target = container.find(currentSelector).first();
+			if (target.length) {
+				const anonymousCheckbox = $(`
 					<div class="d-flex align-items-center" id="anonymous-checkbox-wrapper" style="margin: 0 10px; flex-shrink: 0;">
 						<div class="form-check">
 							<input class="form-check-input" type="checkbox" id="composer-anonymous" name="anonymous" value="1">
@@ -86,37 +86,37 @@ define('anonymous', ['hooks'], function (hooks) {
 				`);
 
 
-                if (target.hasClass('title-container')) {
-                    // Insert into the title container - before the action bar
-                    const actionBar = target.find('.action-bar');
-                    if (actionBar.length) {
-                        actionBar.before(anonymousCheckbox);
-                    } else {
-                        target.append(anonymousCheckbox);
-                    }
-                } else if (target.hasClass('action-bar')) {
-                    // Insert before the action bar
-                    target.before(anonymousCheckbox);
-                } else if (target.hasClass('composer-submit')) {
-                    // Insert before the button's parent container
-                    const buttonParent = target.parent();
-                    if (buttonParent.hasClass('btn-group')) {
-                        buttonParent.before(anonymousCheckbox);
-                    } else {
-                        target.before(anonymousCheckbox);
-                    }
-                } else {
-                    target.append(anonymousCheckbox);
-                }
+				if (target.hasClass('title-container')) {
+					// Insert into the title container - before the action bar
+					const actionBar = target.find('.action-bar');
+					if (actionBar.length) {
+						actionBar.before(anonymousCheckbox);
+					} else {
+						target.append(anonymousCheckbox);
+					}
+				} else if (target.hasClass('action-bar')) {
+					// Insert before the action bar
+					target.before(anonymousCheckbox);
+				} else if (target.hasClass('composer-submit')) {
+					// Insert before the button's parent container
+					const buttonParent = target.parent();
+					if (buttonParent.hasClass('btn-group')) {
+						buttonParent.before(anonymousCheckbox);
+					} else {
+						target.before(anonymousCheckbox);
+					}
+				} else {
+					target.append(anonymousCheckbox);
+				}
 
 
-                break;
-            }
-        }
-    };
+				break;
+			}
+		}
+	};
 
 
-    return Anonymous;
+	return Anonymous;
 });
 
 

--- a/public/src/modules/anonymous.js
+++ b/public/src/modules/anonymous.js
@@ -2,121 +2,121 @@
 
 
 define('anonymous', ['hooks'], function (hooks) {
-   const Anonymous = {};
+    const Anonymous = {};
 
 
-   Anonymous.init = function () {
-       // Handle composer enhancement - add anonymous checkbox
-       hooks.on('action:composer.enhance', function (data) {
-           Anonymous.addCheckboxToComposer(data.container);
-       });
+    Anonymous.init = function () {
+        // Handle composer enhancement - add anonymous checkbox
+        hooks.on('action:composer.enhance', function (data) {
+            Anonymous.addCheckboxToComposer(data.container);
+        });
 
 
-       // Listen to composer creation hooks
-       hooks.on('action:composer.topic.new', function (data) {
-           setTimeout(() => {
-               const composer = $('.composer');
-               if (composer.length) {
-                   Anonymous.addCheckboxToComposer(composer);
-               }
-           }, 100);
-       });
+        // Listen to composer creation hooks
+        hooks.on('action:composer.topic.new', function () {
+            setTimeout(() => {
+                const composer = $('.composer');
+                if (composer.length) {
+                    Anonymous.addCheckboxToComposer(composer);
+                }
+            }, 100);
+        });
 
 
-       hooks.on('action:composer.post.new', function (data) {
-           setTimeout(() => {
-               const composer = $('.composer');
-               if (composer.length) {
-                   Anonymous.addCheckboxToComposer(composer);
-               }
-           }, 100);
-       });
+        hooks.on('action:composer.post.new', function () {
+            setTimeout(() => {
+                const composer = $('.composer');
+                if (composer.length) {
+                    Anonymous.addCheckboxToComposer(composer);
+                }
+            }, 100);
+        });
 
 
-       // Handle composer submission - add anonymous data
-       hooks.on('filter:composer.submit', function (data) {
-           const composerEl = data.composerEl || $('.composer');
-           const checked = composerEl.find('#composer-anonymous').is(':checked');
+        // Handle composer submission - add anonymous data
+        hooks.on('filter:composer.submit', function (data) {
+            const composerEl = data.composerEl || $('.composer');
+            const checked = composerEl.find('#composer-anonymous').is(':checked');
 
 
-           data.composerData = data.composerData || {};
-           if (checked) {
-               data.composerData.anonymous = 1;
-           } else {
-               delete data.composerData.anonymous;
-           }
+            data.composerData = data.composerData || {};
+            if (checked) {
+                data.composerData.anonymous = 1;
+            } else {
+                delete data.composerData.anonymous;
+            }
 
 
-           return data;
-       });
-   };
+            return data;
+        });
+    };
 
 
-   Anonymous.addCheckboxToComposer = function (container) {
-       if (!container || !container.length) {
-           return;
-       }
+    Anonymous.addCheckboxToComposer = function (container) {
+        if (!container || !container.length) {
+            return;
+        }
 
 
-       // Check if checkbox already exists
-       if (container.find('#composer-anonymous').length > 0) {
-           return;
-       }
+        // Check if checkbox already exists
+        if (container.find('#composer-anonymous').length > 0) {
+            return;
+        }
 
 
-       // Look for the title container first, then fallback to other selectors
-       const selectors = [
-           '.title-container',
-           '.action-bar',
-           '.composer-submit',
-           'form'
-       ];
+        // Look for the title container first, then fallback to other selectors
+        const selectors = [
+            '.title-container',
+            '.action-bar',
+            '.composer-submit',
+            'form',
+        ];
 
 
-       for (let selector of selectors) {
-           const target = container.find(selector).first();
-           if (target.length) {
-               const anonymousCheckbox = $(`
-                   <div class="d-flex align-items-center" id="anonymous-checkbox-wrapper" style="margin: 0 10px; flex-shrink: 0;">
-                       <div class="form-check">
-                           <input class="form-check-input" type="checkbox" id="composer-anonymous" name="anonymous" value="1">
-                           <label class="form-check-label" for="composer-anonymous" style="font-size: 14px; margin-left: 5px;">Post anonymously</label>
-                       </div>
-                   </div>
-               `);
+        for (const currentSelector of selectors) {
+            const target = container.find(currentSelector).first();
+            if (target.length) {
+                const anonymousCheckbox = $(`
+					<div class="d-flex align-items-center" id="anonymous-checkbox-wrapper" style="margin: 0 10px; flex-shrink: 0;">
+						<div class="form-check">
+							<input class="form-check-input" type="checkbox" id="composer-anonymous" name="anonymous" value="1">
+							<label class="form-check-label" for="composer-anonymous" style="font-size: 14px; margin-left: 5px;">Post anonymously</label>
+						</div>
+					</div>
+				`);
 
 
-               if (target.hasClass('title-container')) {
-                   // Insert into the title container - before the action bar
-                   const actionBar = target.find('.action-bar');
-                   if (actionBar.length) {
-                       actionBar.before(anonymousCheckbox);
-                   } else {
-                       target.append(anonymousCheckbox);
-                   }
-               } else if (target.hasClass('action-bar')) {
-                   // Insert before the action bar
-                   target.before(anonymousCheckbox);
-               } else if (target.hasClass('composer-submit')) {
-                   // Insert before the button's parent container
-                   const buttonParent = target.parent();
-                   if (buttonParent.hasClass('btn-group')) {
-                       buttonParent.before(anonymousCheckbox);
-                   } else {
-                       target.before(anonymousCheckbox);
-                   }
-               } else {
-                   target.append(anonymousCheckbox);
-               }
+                if (target.hasClass('title-container')) {
+                    // Insert into the title container - before the action bar
+                    const actionBar = target.find('.action-bar');
+                    if (actionBar.length) {
+                        actionBar.before(anonymousCheckbox);
+                    } else {
+                        target.append(anonymousCheckbox);
+                    }
+                } else if (target.hasClass('action-bar')) {
+                    // Insert before the action bar
+                    target.before(anonymousCheckbox);
+                } else if (target.hasClass('composer-submit')) {
+                    // Insert before the button's parent container
+                    const buttonParent = target.parent();
+                    if (buttonParent.hasClass('btn-group')) {
+                        buttonParent.before(anonymousCheckbox);
+                    } else {
+                        target.before(anonymousCheckbox);
+                    }
+                } else {
+                    target.append(anonymousCheckbox);
+                }
 
 
-               break;
-           }
-       }
-   };
+                break;
+            }
+        }
+    };
 
 
-   return Anonymous;
+    return Anonymous;
 });
 
 

--- a/public/src/modules/anonymous.js
+++ b/public/src/modules/anonymous.js
@@ -1,0 +1,122 @@
+'use strict';
+
+
+define('anonymous', ['hooks'], function (hooks) {
+   const Anonymous = {};
+
+
+   Anonymous.init = function () {
+       // Handle composer enhancement - add anonymous checkbox
+       hooks.on('action:composer.enhance', function (data) {
+           Anonymous.addCheckboxToComposer(data.container);
+       });
+
+
+       // Listen to composer creation hooks
+       hooks.on('action:composer.topic.new', function (data) {
+           setTimeout(() => {
+               const composer = $('.composer');
+               if (composer.length) {
+                   Anonymous.addCheckboxToComposer(composer);
+               }
+           }, 100);
+       });
+
+
+       hooks.on('action:composer.post.new', function (data) {
+           setTimeout(() => {
+               const composer = $('.composer');
+               if (composer.length) {
+                   Anonymous.addCheckboxToComposer(composer);
+               }
+           }, 100);
+       });
+
+
+       // Handle composer submission - add anonymous data
+       hooks.on('filter:composer.submit', function (data) {
+           const composerEl = data.composerEl || $('.composer');
+           const checked = composerEl.find('#composer-anonymous').is(':checked');
+
+
+           data.composerData = data.composerData || {};
+           if (checked) {
+               data.composerData.anonymous = 1;
+           } else {
+               delete data.composerData.anonymous;
+           }
+
+
+           return data;
+       });
+   };
+
+
+   Anonymous.addCheckboxToComposer = function (container) {
+       if (!container || !container.length) {
+           return;
+       }
+
+
+       // Check if checkbox already exists
+       if (container.find('#composer-anonymous').length > 0) {
+           return;
+       }
+
+
+       // Look for the title container first, then fallback to other selectors
+       const selectors = [
+           '.title-container',
+           '.action-bar',
+           '.composer-submit',
+           'form'
+       ];
+
+
+       for (let selector of selectors) {
+           const target = container.find(selector).first();
+           if (target.length) {
+               const anonymousCheckbox = $(`
+                   <div class="d-flex align-items-center" id="anonymous-checkbox-wrapper" style="margin: 0 10px; flex-shrink: 0;">
+                       <div class="form-check">
+                           <input class="form-check-input" type="checkbox" id="composer-anonymous" name="anonymous" value="1">
+                           <label class="form-check-label" for="composer-anonymous" style="font-size: 14px; margin-left: 5px;">Post anonymously</label>
+                       </div>
+                   </div>
+               `);
+
+
+               if (target.hasClass('title-container')) {
+                   // Insert into the title container - before the action bar
+                   const actionBar = target.find('.action-bar');
+                   if (actionBar.length) {
+                       actionBar.before(anonymousCheckbox);
+                   } else {
+                       target.append(anonymousCheckbox);
+                   }
+               } else if (target.hasClass('action-bar')) {
+                   // Insert before the action bar
+                   target.before(anonymousCheckbox);
+               } else if (target.hasClass('composer-submit')) {
+                   // Insert before the button's parent container
+                   const buttonParent = target.parent();
+                   if (buttonParent.hasClass('btn-group')) {
+                       buttonParent.before(anonymousCheckbox);
+                   } else {
+                       target.before(anonymousCheckbox);
+                   }
+               } else {
+                   target.append(anonymousCheckbox);
+               }
+
+
+               break;
+           }
+       }
+   };
+
+
+   return Anonymous;
+});
+
+

--- a/public/src/modules/quickreply.js
+++ b/public/src/modules/quickreply.js
@@ -65,6 +65,7 @@ define('quickreply', [
 				tid: ajaxify.data.tid,
 				handle: undefined,
 				content: replyMsg,
+				anonymous: components.get('topic/quickreply/container').find('input[name="anonymous"]').is(':checked'),
 			};
 			const replyLen = replyMsg.length;
 			if (replyLen < parseInt(config.minimumPostLength, 10)) {

--- a/src/controllers/composer.js
+++ b/src/controllers/composer.js
@@ -47,6 +47,7 @@ exports.post = async function (req, res) {
 		timestamp: Date.now(),
 		content: body.content,
 		handle: body.handle,
+		anonymous: body.anonymous === '1' || body.anonymous === true,
 		fromQueue: false,
 	};
 	req.body.noscript = 'true';

--- a/src/posts/create.js
+++ b/src/posts/create.js
@@ -33,6 +33,9 @@ module.exports = function (Posts) {
 		if (data.toPid) {
 			postData.toPid = data.toPid;
 		}
+		if (data.anonymous) {
+			postData.anonymous = data.anonymous;
+		}
 		if (data.ip && meta.config.trackIpPerPost) {
 			postData.ip = data.ip;
 		}

--- a/src/posts/data.js
+++ b/src/posts/data.js
@@ -7,7 +7,7 @@ const utils = require('../utils');
 const intFields = [
 	'uid', 'pid', 'tid', 'deleted', 'timestamp',
 	'upvotes', 'downvotes', 'deleterUid', 'edited',
-	'replies', 'bookmarks', 'announces',
+	'replies', 'bookmarks', 'announces', 'anonymous',
 ];
 
 module.exports = function (Posts) {

--- a/src/posts/summary.js
+++ b/src/posts/summary.js
@@ -22,7 +22,7 @@ module.exports = function (Posts) {
 		options.escape = options.hasOwnProperty('escape') ? options.escape : false;
 		options.extraFields = options.hasOwnProperty('extraFields') ? options.extraFields : [];
 
-		const fields = ['pid', 'tid', 'toPid', 'url', 'content', 'sourceContent', 'uid', 'timestamp', 'deleted', 'upvotes', 'downvotes', 'replies', 'handle'].concat(options.extraFields);
+		const fields = ['pid', 'tid', 'toPid', 'url', 'content', 'sourceContent', 'uid', 'timestamp', 'deleted', 'upvotes', 'downvotes', 'replies', 'handle', 'anonymous'].concat(options.extraFields);
 
 		let posts = await Posts.getPostsFields(pids, fields);
 		posts = posts.filter(Boolean);
@@ -50,8 +50,22 @@ module.exports = function (Posts) {
 			// toPid is nullable so it is casted separately
 			post.toPid = utils.isNumber(post.toPid) ? parseInt(post.toPid, 10) : post.toPid;
 
-			post.user = uidToUser[post.uid];
-			Posts.overrideGuestHandle(post, post.handle);
+			// Handle anonymous posts
+			if (post.anonymous) {
+				post.user = {
+					uid: 0,
+					username: 'Anonymous User',
+					userslug: '',
+					picture: '',
+					'icon:text': '?',
+					'icon:bgColor': '#aaa',
+					status: 'offline',
+					displayname: 'Anonymous User',
+				};
+			} else {
+				post.user = uidToUser[post.uid];
+				Posts.overrideGuestHandle(post, post.handle);
+			}
 			post.handle = undefined;
 			post.topic = tidToTopic[post.tid];
 			post.category = post.topic && cidToCategory[post.topic.cid];

--- a/src/topics/create.js
+++ b/src/topics/create.js
@@ -251,7 +251,9 @@ module.exports = function (Topics) {
 		]);
 
 		// Returned data is a superset of post summary data
-		postData.user = userInfo;
+		if (!postData.anonymous) {
+			postData.user = userInfo;
+		}
 		postData.index = postData.topic.postcount - 1;
 		postData.bookmarked = false;
 		postData.display_edit_tools = true;

--- a/src/topics/teaser.js
+++ b/src/topics/teaser.js
@@ -43,7 +43,7 @@ module.exports = function (Topics) {
 		});
 
 		const [allPostData, callerSettings] = await Promise.all([
-			posts.getPostsFields(teaserPids, ['pid', 'uid', 'timestamp', 'tid', 'content', 'sourceContent']),
+			posts.getPostsFields(teaserPids, ['pid', 'uid', 'timestamp', 'tid', 'content', 'sourceContent', 'anonymous']),
 			user.getSettings(uid),
 		]);
 		let postData = allPostData.filter(post => post && post.pid);
@@ -64,7 +64,21 @@ module.exports = function (Topics) {
 				post.uid = 0;
 			}
 
-			post.user = users[post.uid];
+			// Handle anonymous posts
+			if (post.anonymous) {
+				post.user = {
+					uid: 0,
+					username: 'Anonymous User',
+					userslug: '',
+					picture: '',
+					'icon:text': '?',
+					'icon:bgColor': '#aaa',
+					displayname: 'Anonymous User',
+				};
+			} else {
+				post.user = users[post.uid];
+			}
+
 			post.timestampISO = utils.toISOString(post.timestamp);
 			tidToPost[post.tid] = post;
 		});

--- a/vendor/nodebb-theme-harmony-2.1.15/templates/partials/topic/quickreply.tpl
+++ b/vendor/nodebb-theme-harmony-2.1.15/templates/partials/topic/quickreply.tpl
@@ -13,6 +13,10 @@
 			<textarea rows="4" name="content" component="topic/quickreply/text" class="form-control mousetrap" placeholder="[[modules:composer.textarea.placeholder]]"></textarea>
 			<div class="imagedrop"><div>[[topic:composer.drag-and-drop-images]]</div></div>
 		</div>
+		<div class="form-check">
+			<input type="checkbox" name="anonymous" id="quickreply-anonymous" class="form-check-input" value="1">
+			<label for="quickreply-anonymous" class="form-check-label">Post anonymously</label>
+		</div>
 		<div>
 			<div class="d-flex justify-content-end gap-2">
 				<button type="button" component="topic/quickreply/upload/button" class="btn btn-ghost btn-sm border"><i class="fa fa-upload"></i></button>


### PR DESCRIPTION
**Context**
This pull request adds support for anonymous posting across the forum. It introduces a per-post/OP option that allows authors to hide their identity. The work includes backend API & database changes, client UI (composer checkbox), jQuery hooks, etc.

**Description**
A new “Post anonymously” checkbox is available in the topic composer. When checked, the post is created with isAnonymous: true. The UI renders the author as “Anonymous User” with a question mark avatar, and hides profile links. Quick replies also have the same support, where replies to a topic appear as "Anonymous User" as well.
<img width="1093" height="762" alt="Screenshot 2025-09-26 at 10 15 27 PM" src="https://github.com/user-attachments/assets/fd19dd00-f0bc-46c6-a637-40c1177364a4" />

**Changes**
Frontend: Checkbox was added in two locations. First, the anonymous checkbox was dynamically injected in the new topic form because static assets were in the node_modules folder. As a workaround to editing node_modules, the html was injected in a hook. `anonymous.js`
The checbox was also added in the quick reply tpl file. 'quickreply.tpl'
Backend: The anonymous flag was passed down from the frontend to the backend all the way to the database level in 'posts/create.js'
Display: The backend information was fetched and if the anonymous flag was identified, an anonymous user object was passed and displayed in the frontend with username 'Anonymous User' and a profile picture of a question mark.

(Some of the code was written in assistance by generative AI)