### PR TITLE
Feat: Sort topics by admin replied in category #86

### DIFF
--- a/UserGuide.md
+++ b/UserGuide.md
@@ -1,0 +1,11 @@
+# User Guide
+
+## Admin-Replied Topic Sorting
+
+The Admin-Replied sorting feature adds a new way to sort topics based on if an admin has replied in that topic or not, for users who want credible admin information. This feature prioritizes topics that have received replies from administrators, making it easier to identify discussions with official responses. Topics with admin replies are sorted by the timestamp of their most recent admin response, while topics without admin replies fall back to standard recent sorting.
+
+To use this feature, apply the sort parameter `admin_replied` or `admin-replied` when browsing topics through the API or URL parameters (e.g., `/category/1?sort=admin_replied`). The system efficiently processes this sorting by batching database queries and checking administrator privileges to identify which users qualify as administrators. When a topic has multiple admin replies, only the most recent timestamp is used for sorting purposes.
+
+**Manual Testing**: Run on localhost, then create topics with different combinations of admin and regular user replies, then verify that admin-replied topics appear first, ordered by recency of admin responses. 
+
+**Automated Tests**: Located at `/test/topics/admin-replied.js`, the test suite includes 5 focused test cases covering core sorting logic, chronological ordering, alias compatibility, edge case handling, and multiple admin reply scenarios. Run tests with `npm run test -- test/topics/admin-replied.js` to verify functionality. The tests ensure topics with admin replies are prioritized, properly ordered by admin reply timestamps, and that both parameter variants work identically.

--- a/public/language/en-GB/admin/settings/post.json
+++ b/public/language/en-GB/admin/settings/post.json
@@ -9,6 +9,7 @@
 	"sorting.most-votes": "Most Votes",
 	"sorting.most-posts": "Most Posts",
 	"sorting.most-views": "Most Views",
+	"sorting.admin-replied": "Admin Replies",
 	"sorting.topic-default": "Default Topic Sorting",
 	"length": "Post Length",
 	"post-queue": "Post Queue",

--- a/public/language/en-GB/topic.json
+++ b/public/language/en-GB/topic.json
@@ -223,6 +223,7 @@
 	"most-votes": "Most Votes",
 	"most-posts": "Most Posts",
 	"most-views": "Most Views",
+	"admin-replied": "Admin Replies",
 
 	"stale.title": "Create new topic instead?",
 	"stale.warning": "The topic you are replying to is quite old. Would you like to create a new topic instead, and reference this one in your reply?",

--- a/public/language/en-US/admin/settings/post.json
+++ b/public/language/en-US/admin/settings/post.json
@@ -9,6 +9,7 @@
 	"sorting.most-votes": "Most Votes",
 	"sorting.most-posts": "Most Posts",
 	"sorting.most-views": "Most Views",
+	"sorting.admin-replied": "Admin Replies",
 	"sorting.topic-default": "Default Topic Sorting",
 	"length": "Post Length",
 	"post-queue": "Post Queue",

--- a/public/language/en-US/topic.json
+++ b/public/language/en-US/topic.json
@@ -200,6 +200,7 @@
     "most-votes": "Most Votes",
     "most-posts": "Most Posts",
     "most-views": "Most Views",
+    "admin-replied": "Admin Replies",
     "stale.title": "Create new topic instead?",
     "stale.warning": "The topic you are replying to is quite old. Would you like to create a new topic instead, and reference this one in your reply?",
     "stale.create": "Create a new topic",

--- a/src/controllers/activitypub/topics.js
+++ b/src/controllers/activitypub/topics.js
@@ -15,7 +15,7 @@ const helpers = require('../helpers');
 const controller = module.exports;
 
 const validSorts = [
-	'recently_replied', 'recently_created', 'most_posts', 'most_votes', 'most_views',
+	'recently_replied', 'recently_created', 'most_posts', 'most_votes', 'most_views', 'admin_replied', 'admin-replied',
 ];
 
 controller.list = async function (req, res) {

--- a/src/controllers/category.js
+++ b/src/controllers/category.js
@@ -22,7 +22,7 @@ const categoryController = module.exports;
 const url = nconf.get('url');
 const relative_path = nconf.get('relative_path');
 const validSorts = [
-	'recently_replied', 'recently_created', 'most_posts', 'most_votes', 'most_views',
+	'recently_replied', 'recently_created', 'most_posts', 'most_votes', 'most_views', 'admin_replied', 'admin-replied',
 ];
 
 categoryController.get = async function (req, res, next) {

--- a/src/views/partials/category/sort.tpl
+++ b/src/views/partials/category/sort.tpl
@@ -11,6 +11,13 @@
 				<i class="flex-shrink-0 fa fa-fw text-secondary"></i>
 			</a>
 		</li>
+			<li>
+				<a class="dropdown-item rounded-1 d-flex align-items-center gap-2" href="#" data-sort="admin_replied" role="menuitem">
+					<span class="flex-grow-1">[[topic:admin-replied]]</span>
+					<i class="flex-shrink-0 fa fa-fw text-secondary"></i>
+				</a>
+			</li>
+		</li>
 		<li>
 			<a class="dropdown-item rounded-1 d-flex align-items-center gap-2" href="#" data-sort="recently_created" role="menuitem">
 				<span class="flex-grow-1">[[topic:recently-created]]</span>

--- a/test/topics/admin-replied.js
+++ b/test/topics/admin-replied.js
@@ -1,0 +1,183 @@
+'use strict';
+
+const assert = require('assert');
+const db = require('../mocks/databasemock');
+const topics = require('../../src/topics');
+const posts = require('../../src/posts');
+const categories = require('../../src/categories');
+const privileges = require('../../src/privileges');
+const User = require('../../src/user');
+const groups = require('../../src/groups');
+
+describe('Topics Admin Replied Sorting', () => {
+	let category;
+	let adminUid;
+	let regularUid;
+	let topic1;
+	let topic2;
+	let topic3;
+
+	before(async () => {
+		// Create users
+		adminUid = await User.create({ username: 'testadmin', password: '123456' });
+		regularUid = await User.create({ username: 'testuser', password: '123456' });
+
+		// Make one user an admin
+		await groups.join('administrators', adminUid);
+
+		// Create test category
+		category = await categories.create({
+			name: 'Admin Reply Test Category',
+			description: 'Test category for admin reply sorting',
+		});
+
+		// Create test topics
+		const topic1Result = await topics.post({
+			uid: regularUid,
+			cid: category.cid,
+			title: 'Topic with admin reply',
+			content: 'This topic will have an admin reply',
+		});
+		topic1 = topic1Result.topicData;
+
+		const topic2Result = await topics.post({
+			uid: regularUid,
+			cid: category.cid,
+			title: 'Topic with no admin reply',
+			content: 'This topic will have only regular user replies',
+		});
+		topic2 = topic2Result.topicData;
+
+		const topic3Result = await topics.post({
+			uid: regularUid,
+			cid: category.cid,
+			title: 'Topic with later admin reply',
+			content: 'This topic will have a more recent admin reply',
+		});
+		topic3 = topic3Result.topicData;
+
+		// Add replies to topics
+		// Topic 1: regular reply, then admin reply
+		await topics.reply({ uid: regularUid, content: 'Regular user reply', tid: topic1.tid });
+		await new Promise(resolve => setTimeout(resolve, 100)); // Small delay to ensure different timestamps
+		await topics.reply({ uid: adminUid, content: 'Admin reply to topic 1', tid: topic1.tid });
+
+		// Topic 2: only regular user replies
+		await topics.reply({ uid: regularUid, content: 'Regular reply 1', tid: topic2.tid });
+		await topics.reply({ uid: regularUid, content: 'Regular reply 2', tid: topic2.tid });
+
+		// Topic 3: admin reply (more recent than topic 1)
+		await new Promise(resolve => setTimeout(resolve, 200)); // Ensure this is later
+		await topics.reply({ uid: adminUid, content: 'More recent admin reply', tid: topic3.tid });
+	});
+
+	describe('admin_replied sorting', () => {
+		it('should sort topics with admin replies before those without', async () => {
+			const data = await topics.getSortedTopics({
+				cids: [category.cid],
+				uid: regularUid,
+				start: 0,
+				stop: -1,
+				sort: 'admin_replied',
+			});
+
+			const topicTitles = data.topics.map(t => t.title);
+			const adminRepliedTopics = topicTitles.filter(title =>
+				title === 'Topic with admin reply' || title === 'Topic with later admin reply'
+			);
+			const noAdminReplyIndex = topicTitles.indexOf('Topic with no admin reply');
+			const firstAdminReplyIndex = Math.min(
+				...adminRepliedTopics.map(title => topicTitles.indexOf(title))
+			);
+
+			assert(firstAdminReplyIndex < noAdminReplyIndex,
+				'Topics with admin replies should be sorted before those without');
+		});
+
+		it('should sort admin-replied topics by most recent admin reply timestamp', async () => {
+			const data = await topics.getSortedTopics({
+				cids: [category.cid],
+				uid: regularUid,
+				start: 0,
+				stop: -1,
+				sort: 'admin_replied',
+			});
+
+			const topicTitles = data.topics.map(t => t.title);
+			const laterReplyIndex = topicTitles.indexOf('Topic with later admin reply');
+			const earlierReplyIndex = topicTitles.indexOf('Topic with admin reply');
+
+			assert(laterReplyIndex < earlierReplyIndex,
+				'Topic with more recent admin reply should come first');
+		});
+
+		it('should work with admin-replied alias', async () => {
+			const dataHyphen = await topics.getSortedTopics({
+				cids: [category.cid],
+				uid: regularUid,
+				start: 0,
+				stop: -1,
+				sort: 'admin-replied',
+			});
+
+			const dataUnderscore = await topics.getSortedTopics({
+				cids: [category.cid],
+				uid: regularUid,
+				start: 0,
+				stop: -1,
+				sort: 'admin_replied',
+			});
+
+			const titlesHyphen = dataHyphen.topics.map(t => t.title);
+			const titlesUnderscore = dataUnderscore.topics.map(t => t.title);
+			assert.deepStrictEqual(titlesHyphen, titlesUnderscore,
+				'admin-replied and admin_replied should produce identical results');
+		});
+
+		it('should handle empty categories gracefully', async () => {
+			const emptyCategory = await categories.create({
+				name: 'Empty Category',
+				description: 'Empty test category',
+			});
+
+			const data = await topics.getSortedTopics({
+				cids: [emptyCategory.cid],
+				uid: regularUid,
+				start: 0,
+				stop: -1,
+				sort: 'admin_replied',
+			});
+
+			assert.strictEqual(data.topics.length, 0);
+			assert.strictEqual(data.topicCount, 0);
+		});
+
+		it('should handle multiple admin replies correctly', async () => {
+			const multiAdminResult = await topics.post({
+				uid: regularUid,
+				cid: category.cid,
+				title: 'Multiple admin replies topic',
+				content: 'This topic will have multiple admin replies',
+			});
+
+			await topics.reply({ uid: adminUid, content: 'First admin reply', tid: multiAdminResult.topicData.tid });
+			await new Promise(resolve => setTimeout(resolve, 100));
+			await topics.reply({ uid: adminUid, content: 'Latest admin reply', tid: multiAdminResult.topicData.tid });
+
+			const data = await topics.getSortedTopics({
+				cids: [category.cid],
+				uid: regularUid,
+				start: 0,
+				stop: -1,
+				sort: 'admin_replied',
+			});
+
+			const multiAdminTopic = data.topics.find(t => t.title === 'Multiple admin replies topic');
+			assert(multiAdminTopic, 'Should find topic with multiple admin replies');
+
+			// Should be first due to most recent admin reply
+			assert.strictEqual(data.topics[0].title, 'Multiple admin replies topic',
+				'Topic with most recent admin reply should be first');
+		});
+	});
+});


### PR DESCRIPTION
**Context**
This pull request integrates an additional feature of sorting topics by admin replies. It sort topics based on if an admin has replied in that topic or not, with posts with replies from admins coming before posts without admin replies. Those with admin replies are sorted by recent timestamp, with recent topics coming before later topics. 


<img width="228" height="255" alt="Screenshot 2025-10-08 at 12 04 00 PM" src="https://github.com/user-attachments/assets/5fb7691d-4dab-48dc-910f-678612506a93" />


<img width="1344" height="710" alt="Screenshot 2025-10-08 at 12 04 11 PM" src="https://github.com/user-attachments/assets/58b438b0-a523-4eea-9494-61cb89b6b382" />

**Changes**
Frontend: Modified file `sort.tpl` to include dropdown sort option admin-replied. Added language support for this new option in `en-US` and `en-GB` directories.

Backend: Modified file `sorted.js` to implement the admin_replied sorting algorithm that computes admin reply timestamps for topics and prioritizes them chronologically. Updated `topics.js` to route sorting requests to the correct function.

Testing: Created 5 test cases in new file `admin-replied.js` with 5 test cases covering core sorting logic, chronological ordering, etc.

User Guide: Added new file `UserGuide.md` and included detailed documentation on how to test the new feature.

* Generative AI was used in assistance in development of the feature, especially the backend in finding the flow of relevant files, etc.
* Generative AI was used in generating test cases for this feature